### PR TITLE
find the catkin package before calling catkin_package() function in c…

### DIFF
--- a/movidius_ncs_launch/CMakeLists.txt
+++ b/movidius_ncs_launch/CMakeLists.txt
@@ -15,6 +15,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(movidius_ncs_launch)
 
+find_package(catkin REQUIRED)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS


### PR DESCRIPTION
…make file. Without this, the catkin tools from python-catkin-tools(not catkin_make) will report build issue.