### PR TITLE
use x86 intrinsic to optimize the float conversion

### DIFF
--- a/movidius_ncs_lib/CMakeLists.txt
+++ b/movidius_ncs_lib/CMakeLists.txt
@@ -101,6 +101,10 @@ if(UNIX OR APPLE)
   set( CUDA_PROPAGATE_HOST_FLAGS OFF )
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_FORTIFY_SOURCE=2")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+
+  # Add x86 intrinsic compiler support
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 
 # Install nodelet library

--- a/movidius_ncs_lib/include/movidius_ncs_lib/tensor.h
+++ b/movidius_ncs_lib/include/movidius_ncs_lib/tensor.h
@@ -46,8 +46,10 @@ public:
     return 3 * height_ * width_ * sizeof(uint16_t);
   }
 
+#if !defined(__i386__) && !defined(__x86_64__)
   static void fp32tofp16(uint16_t* __restrict out, float in);
   static void fp16tofp32(float* __restrict out, uint16_t in);
+#endif
 
 private:
   std::vector<uint16_t> tensor_;

--- a/movidius_ncs_lib/src/graph.cpp
+++ b/movidius_ncs_lib/src/graph.cpp
@@ -18,6 +18,9 @@
 #include <string>
 #include <utility>
 #include <vector>
+#if defined(__i386__) || defined(__x86_64__)
+#include <x86intrin.h>
+#endif
 #include <ros/console.h>
 #include "movidius_ncs_lib/exception.h"
 #include "movidius_ncs_lib/exception_util.h"
@@ -84,7 +87,11 @@ ItemsPtr Graph::getDetectedItems()
   for (size_t index = 0; index < length / 2; ++index)
   {
     float fp32;
+#if defined(__i386__) || defined(__x86_64__)
+    fp32 = _cvtsh_ss(probabilities[index]);
+#else
     Tensor::fp16tofp32(&fp32, probabilities[index]);
+#endif
     Item item;
     item.category = categories_[index];
     item.probability = fp32;

--- a/movidius_ncs_lib/src/tensor.cpp
+++ b/movidius_ncs_lib/src/tensor.cpp
@@ -16,6 +16,9 @@
 
 #include <utility>
 #include <vector>
+#if defined(__i386__) || defined(__x86_64__)
+#include <x86intrin.h>
+#endif
 #include <opencv2/core/mat.hpp>
 #include "movidius_ncs_lib/tensor.h"
 
@@ -48,15 +51,22 @@ Tensor::Tensor(const cv::Mat& original,
     uint16_t r16;
     uint16_t g16;
     uint16_t b16;
+#if defined(__i386__) || defined(__x86_64__)
+    r16 = _cvtss_sh(r32, 0);
+    g16 = _cvtss_sh(g32, 0);
+    b16 = _cvtss_sh(b32, 0);
+#else
     Tensor::fp32tofp16(&r16, r32);
     Tensor::fp32tofp16(&g16, g32);
     Tensor::fp32tofp16(&b16, b32);
+#endif
     tensor_.push_back(r16);
     tensor_.push_back(g16);
     tensor_.push_back(b16);
   }
 }
 
+#if !defined(__i386__) && !defined(__x86_64__)
 void Tensor::fp16tofp32(float* __restrict out, uint16_t in)
 {
   uint32_t t1;
@@ -91,4 +101,6 @@ void Tensor::fp32tofp16(uint16_t* __restrict out, float in)
   t1 |= t2;
   *(reinterpret_cast<uint16_t*>(out)) = t1;
 }
+#endif // !defined(__i386__) && !defined(__x86_64__)
+
 }   // namespace movidius_ncs_lib


### PR DESCRIPTION
Intel processor provide many intrinsics instruction like MMX, SSE for performance optimization, we could consider to use these intrinsics in C++ code. Please refer the detail introduction at https://software.intel.com/en-us/node/523351