### PR TITLE
remove deprecated variant names on NCSDK v1.09

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 1 Introduction
 The Movidius™ Neural Compute Stick ([NCS](https://developer.movidius.com/)) is a tiny fanless deep learning device that you can use to learn AI programming at the edge. NCS is powered by the same low power high performance Movidius™ Vision Processing Unit ([VPU](https://www.movidius.com/solutions/vision-processing-unit)) that can be found in millions of smart security cameras, gesture controlled drones, industrial machine vision equipment, and more.  
-This project is a ROS wrapper for NC API of [NCS SDK](https://ncsforum.movidius.com/discussion/98/latest-version-movidius-neural-compute-sdk), providing the following features in the latest release(v0.3.0):
+This project is a ROS wrapper for NC API of [NC SDK](https://movidius.github.io/ncsdk/), providing the following features in the latest release(v0.3.0):
 * A ROS service for classifying objects in a static image file
 * A ROS publisher for classifying objects in a video stream from a USB camera
 * Demo applications to show the capbilities of ROS service and publisher
@@ -18,12 +18,12 @@ This project is a ROS wrapper for NC API of [NCS SDK](https://ncsforum.movidius.
 ## 3 Environment Setup
 * Install ROS Kinetic Desktop-Full ([guide](http://wiki.ros.org/kinetic/Installation/Ubuntu)) 
 * Create a catkin workspace ([guide](http://wiki.ros.org/catkin/Tutorials/create_a_workspace))
-* Install NCS SDK ([guide](https://developer.movidius.com/start/software-setup))  
-* Create a symbol link in ```/opt``` to the installation path of NCS SDK ```<ncs-sdk-installation-path>```
+* Install NC SDK [v1.09.00](https://github.com/movidius/ncsdk.git) ([NCS Quick Start](https://developer.movidius.com/start))  
+* Create a symbol link in ```/opt/movidius``` to the folder of ```example``` in NC SDK directory which is git-cloned from [github](https://github.com/movidius/ncsdk.git)
 ```Shell
-sudo ln -s <ncs-sdk-installation-path> /opt/NCS
+sudo ln -s <ncsdk-directory>/examples /opt/movidius/examples
 ```  
-After that, make sure you can find graph data in ```/opt/NCS/ncapi/networks``` and image data in ```/opt/NCS/ncapi/images```
+After that, make sure you can find graph data in ```/opt/movidius/examples/caffe``` or ```/opt/movidius/examples/tensorflow``` and image data in ```/opt/movidius/examples/data/images```
 * Install ROS package for different cameras as needed. e.g.
   1. Standard USB camera
   ```Shell
@@ -112,21 +112,21 @@ rosrun movidius_ncs_example movidius_ncs_example_image <image_path_to_be_inferre
 ```
 e.g.
 ```Shell
-rosrun movidius_ncs_example movidius_ncs_example_image /opt/NCS/ncapi/images/cat.jpg
+rosrun movidius_ncs_example movidius_ncs_example_image /opt/movidius/examples/data/images/cat.jpg
 ```
 ### 5.3 Choose Different CNN Models
 You can choose different CNN Models for inference through the argument of ```network_conf_path```. e.g.  
 Using Realsense camera
 ```Shell
 #one console
-roslaunch movidius_ncs_launch ncs_realsense.launch network_conf_path:="/opt/NCS/ncapi/networks/SqueezeNet/"
+roslaunch movidius_ncs_launch ncs_realsense.launch network_conf_path:="/opt/movidius/examples/caffe/SqueezeNet"
 #another console
 roslaunch movidius_ncs_launch ncs_stream_example.launch
 ```
 Using standard USB camera
 ```Shell
 #one console
-roslaunch movidius_ncs_launch ncs_usbcam.launch network_conf_path:="/opt/NCS/ncapi/networks/AlexNet/"
+roslaunch movidius_ncs_launch ncs_usbcam.launch network_conf_path:="/opt/movidius/examples/caffe/AlexNet"
 #another console
 roslaunch movidius_ncs_launch ncs_stream_example.launch camera_topic:="/usb_cam/image_raw"
 ```

--- a/movidius_ncs_lib/src/device.cpp
+++ b/movidius_ncs_lib/src/device.cpp
@@ -91,7 +91,7 @@ void Device::setLogLevel(LogLevel log_level)
 {
   int level = log_level;
   int ret = mvncSetDeviceOption(0,
-                                MVNC_LOGLEVEL,
+                                MVNC_LOG_LEVEL,
                                 static_cast<void*>(&level),
                                 sizeof(level));
   ExceptionUtil::tryToThrowMvncException(ret);
@@ -103,7 +103,7 @@ Device::LogLevel Device::getLogLevel()
   int level;
   unsigned int size_of_level = sizeof(level);
   int ret = mvncGetDeviceOption(handle_,
-                                MVNC_LOGLEVEL,
+                                MVNC_LOG_LEVEL,
                                 reinterpret_cast<void**>(&level),
                                 &size_of_level);
   ExceptionUtil::tryToThrowMvncException(ret);
@@ -132,7 +132,7 @@ void* Device::getHandle()
 void Device::find()
 {
   assert(handle_ == nullptr);
-  char name[MVNC_MAXNAMESIZE];
+  char name[MVNC_MAX_NAME_SIZE];
   int ret = mvncGetDeviceName(index_, name, sizeof(name));
   ExceptionUtil::tryToThrowMvncException(ret);
   name_ = name;

--- a/movidius_ncs_lib/src/exception_util.cpp
+++ b/movidius_ncs_lib/src/exception_util.cpp
@@ -56,12 +56,12 @@ std::map<int, std::string> CODE2STR =
   }
   ,
   {
-    MVNC_MVCMDNOTFOUND,
+    MVNC_MVCMD_NOT_FOUND,
     "the file named MvNCAPI.mvcmd should be installed in the mvnc direcotry"
   }
   ,
   {
-    MVNC_NODATA,
+    MVNC_NO_DATA,
     "no data to return"
   }
   ,
@@ -71,19 +71,19 @@ std::map<int, std::string> CODE2STR =
   }
   ,
   {
-    MVNC_UNSUPPORTEDGRAPHFILE,
+    MVNC_UNSUPPORTED_GRAPH_FILE,
     "the graph file may have been created with an incompatible prior version of the Toolkit"
   }
   ,
   {
-    MVNC_MYRIADERROR,
+    MVNC_MYRIAD_ERROR,
     "an error has been reported by Movidius VPU"
   }
 };
 
 void ExceptionUtil::tryToThrowMvncException(int code)
 {
-  assert(MVNC_OK >= code && code >= MVNC_MYRIADERROR);
+  assert(MVNC_OK >= code && code >= MVNC_MYRIAD_ERROR);
 
   try
   {
@@ -114,12 +114,12 @@ void ExceptionUtil::tryToThrowMvncException(int code)
       throw MvncTimeout(msg);
     }
 
-    if (code == MVNC_MVCMDNOTFOUND)
+    if (code == MVNC_MVCMD_NOT_FOUND)
     {
       throw MvncMvCmdNotFound(msg);
     }
 
-    if (code == MVNC_NODATA)
+    if (code == MVNC_NO_DATA)
     {
       throw MvncNoData(msg);
     }
@@ -129,12 +129,12 @@ void ExceptionUtil::tryToThrowMvncException(int code)
       throw MvncGone(msg);
     }
 
-    if (code == MVNC_UNSUPPORTEDGRAPHFILE)
+    if (code == MVNC_UNSUPPORTED_GRAPH_FILE)
     {
       throw MvncUnsupportedGraphFile(msg);
     }
 
-    if (code == MVNC_MYRIADERROR)
+    if (code == MVNC_MYRIAD_ERROR)
     {
       throw MvncMyriadError(msg);
     }

--- a/movidius_ncs_lib/src/graph.cpp
+++ b/movidius_ncs_lib/src/graph.cpp
@@ -105,7 +105,7 @@ std::string Graph::getDebugInfo()
   char* debug_info;
   unsigned int length;
   int ret = mvncGetGraphOption(handle_,
-                               MVNC_DEBUGINFO,
+                               MVNC_DEBUG_INFO,
                                reinterpret_cast<void**>(&debug_info),
                                &length);
   ExceptionUtil::tryToThrowMvncException(ret);
@@ -119,7 +119,7 @@ float Graph::getTimeTaken()
   float* time_taken;
   unsigned int length;
   int ret = mvncGetGraphOption(handle_,
-                               MVNC_TIMETAKEN,
+                               MVNC_TIME_TAKEN,
                                reinterpret_cast<void**>(&time_taken),
                                &length);
   ExceptionUtil::tryToThrowMvncException(ret);


### PR DESCRIPTION
replace deprecated variant names with the up-to-date ones on NCSDK v1.09

Signed-off-by: Xiaojun Huang <xiaojun.huang@intel.com>