### PR TITLE
Fix compile issue on Intel old platforms for x86 intrinsic optimization

### DIFF
--- a/movidius_ncs_lib/CMakeLists.txt
+++ b/movidius_ncs_lib/CMakeLists.txt
@@ -104,6 +104,7 @@ if(UNIX OR APPLE)
 
   # Add x86 intrinsic compiler support
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mf16c")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 


### PR DESCRIPTION
Add "mf16c" flag to support compiling platforms earlier than Ivy Bridge.

Signed-off-by: Chao Li <chao1.li@intel.com>