### PR TITLE
fix cmakelist opencv error for movidius_ncs_lib

### DIFF
--- a/movidius_ncs_lib/CMakeLists.txt
+++ b/movidius_ncs_lib/CMakeLists.txt
@@ -32,7 +32,7 @@ include_directories(
 )
 
 # add opencv dependency
-find_package(OpenCV)
+find_package(OpenCV 3 REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 find_path(MVNC_HEADER_FILE


### PR DESCRIPTION
Hi
I add (OpenCV 3 REQUIRED) in  movidius_ncs_lib/CMakeLists.txt to avoid version issue when compiling in the system which has both opencv 2 and 3.