### PR TITLE
change x and y of bounding box to left-top point

### DIFF
--- a/movidius_ncs_example/src/image_detection.cpp
+++ b/movidius_ncs_example/src/image_detection.cpp
@@ -66,15 +66,13 @@ int main(int argc, char** argv)
              srv.response.objects.objects_vector[i].roi.width,
              srv.response.objects.objects_vector[i].roi.height);
 
-    int x = srv.response.objects.objects_vector[i].roi.x_offset;
-    int y = srv.response.objects.objects_vector[i].roi.y_offset;
+    int xmin = srv.response.objects.objects_vector[i].roi.x_offset;
+    int ymin = srv.response.objects.objects_vector[i].roi.y_offset;
     int w = srv.response.objects.objects_vector[i].roi.width;
     int h = srv.response.objects.objects_vector[i].roi.height;
 
-    int xmin = ((x - w / 2) > 0)? (x - w / 2) : 0;
-    int xmax = ((x + w / 2) < width)? (x + w / 2) : width;
-    int ymin = ((y - h / 2) > 0)? (y - h / 2) : 0;
-    int ymax = ((y + h / 2) < height)? (y + h / 2) : height;
+    int xmax = ((xmin + w) < width)? (xmin + w) : width;
+    int ymax = ((ymin + h) < height)? (ymin + h) : height;
 
     cv::Point left_top = cv::Point(xmin, ymin);
     cv::Point right_bottom = cv::Point(xmax, ymax);

--- a/movidius_ncs_example/src/stream_detection.cpp
+++ b/movidius_ncs_example/src/stream_detection.cpp
@@ -39,15 +39,13 @@ void syncCb(const sensor_msgs::ImageConstPtr& img,
     std::stringstream ss;
     ss << obj.object.object_name << ": " << obj.object.probability * 100 << '%';
 
-    int x = obj.roi.x_offset;
-    int y = obj.roi.y_offset;
+    int xmin = obj.roi.x_offset;
+    int ymin = obj.roi.y_offset;
     int w = obj.roi.width;
     int h = obj.roi.height;
 
-    int xmin = ((x - w / 2) > 0)? (x - w / 2) : 0;
-    int xmax = ((x + w / 2) < width)? (x + w / 2) : width;
-    int ymin = ((y - h / 2) > 0)? (y - h / 2) : 0;
-    int ymax = ((y + h / 2) < height)? (y + h / 2) : height;
+    int xmax = ((xmin + w) < width)? (xmin + w) : width;
+    int ymax = ((ymin + h) < height)? (ymin + h) : height;
 
     cv::Point left_top = cv::Point(xmin, ymin);
     cv::Point right_bottom = cv::Point(xmax, ymax);


### PR DESCRIPTION
the previous one is central, but according to the definition of x and y of ROI, it should be the left-top point.

Signed-off-by: Xiaojun Huang <xiaojun.huang@intel.com>