### PR TITLE
Fix the launching issue on Apollo Lake based board

### DIFF
--- a/movidius_ncs_lib/CMakeLists.txt
+++ b/movidius_ncs_lib/CMakeLists.txt
@@ -99,17 +99,26 @@ if(UNIX OR APPLE)
   # Generic flags.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-operator-names -Wformat -Wformat-security -Wall")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-  # Dot not forward c++11 flag to GPU beucause it is not supported
-  set( CUDA_PROPAGATE_HOST_FLAGS OFF )
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_FORTIFY_SOURCE=2")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
-  # Add x86 intrinsic compiler support
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mf16c")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-  # Add OpenMP support
+ # Add OpenMP support
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+endif()
+
+# Add x86 intrinsic compiler support
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+execute_process(
+    COMMAND bash -c "lscpu | grep -qi flags | grep -qi flags | grep -qi f16c"
+    RESULT_VARIABLE SUPPORT_F16C)
+if (SUPPORT_F16C EQUAL 0)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mf16c")
+  add_definitions(-DSUPPORT_MF16C)
+endif()
+
+execute_process(
+    COMMAND bash -c "lscpu | grep -qi flags | grep -qi flags | grep -qi sse4_1"
+    RESULT_VARIABLE SUPPORT_SSE41)
+if (SUPPORT_SSE41 EQUAL 0)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
 endif()
 
 # Install nodelet library

--- a/movidius_ncs_lib/include/movidius_ncs_lib/tensor.h
+++ b/movidius_ncs_lib/include/movidius_ncs_lib/tensor.h
@@ -55,7 +55,7 @@ public:
   {
     return image_height_;
   }
-#if !defined(__i386__) && !defined(__x86_64__)
+#ifndef SUPPORT_F16C
   static void fp32tofp16(uint16_t* __restrict out, float in);
   static void fp16tofp32(float* __restrict out, uint16_t in);
 #endif

--- a/movidius_ncs_lib/src/graph.cpp
+++ b/movidius_ncs_lib/src/graph.cpp
@@ -18,9 +18,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#if defined(__i386__) || defined(__x86_64__)
-#include <x86intrin.h>
-#endif
 #include <ros/console.h>
 #include "movidius_ncs_lib/exception.h"
 #include "movidius_ncs_lib/exception_util.h"

--- a/movidius_ncs_lib/src/ncs.cpp
+++ b/movidius_ncs_lib/src/ncs.cpp
@@ -80,7 +80,7 @@ void NCS::classify()
     for (size_t index = 0; index < length / 2; ++index)
     {
       float fp32;
-#if defined(__i386__) || defined(__x86_64__)
+#ifdef SUPPORT_F16C
       fp32 = _cvtsh_ss(probabilities[index]);
 #else
       Tensor::fp16tofp32(&fp32, probabilities[index]);
@@ -145,7 +145,7 @@ void NCS::detect()
     for (auto fp16 : result16_vector)
     {
       float fp32;
-#if defined(__i386__) || defined(__x86_64__)
+#ifdef SUPPORT_F16C
       fp32 = _cvtsh_ss(fp16);
 #else
       Tensor::fp16tofp32(&fp32, fp16);

--- a/movidius_ncs_lib/src/tensor.cpp
+++ b/movidius_ncs_lib/src/tensor.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 #include <string>
-#if defined(__i386__) || defined(__x86_64__)
+#ifdef SUPPORT_F16C
 #include <x86intrin.h>
 #endif
 #include <opencv2/core/mat.hpp>
@@ -62,7 +62,7 @@ void Tensor::loadImageData(const cv::Mat& image)
     uint16_t r16;
     uint16_t g16;
     uint16_t b16;
-#if defined(__i386__) || defined(__x86_64__)
+#ifdef SUPPORT_F16C
     r16 = _cvtss_sh(r32, 0);
     g16 = _cvtss_sh(g32, 0);
     b16 = _cvtss_sh(b32, 0);
@@ -85,7 +85,7 @@ void Tensor::clearTensor()
   }
 }
 
-#if !defined(__i386__) && !defined(__x86_64__)
+#ifndef SUPPORT_F16C
 void Tensor::fp16tofp32(float* __restrict out, uint16_t in)
 {
   uint32_t t1;
@@ -120,6 +120,6 @@ void Tensor::fp32tofp16(uint16_t* __restrict out, float in)
   t1 |= t2;
   *(reinterpret_cast<uint16_t*>(out)) = t1;
 }
-#endif  // !defined(__i386__) && !defined(__x86_64__)
+#endif
 
 }   // namespace movidius_ncs_lib


### PR DESCRIPTION
This patch fixes the instruction bug on Intel Apollo Lake based board.
The Apollo Lake CPU series don't support F16C instruction. So we remove the "-mf16c" compiling flag for Apollo Lake CPU series. 